### PR TITLE
Improve cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,9 @@ You can compile DROP with ```make``` in the parent directory.
 
 ### Usage
 
-The tool is organized as follows:
-- There are "parent" options (-c, -f, --help, etc) consisting of the main executable and the first option. Ex: ```./drop -c``` or ```./drop -f ```. Everything after the "parent" option are "child" options for commands.
+- See commands ```./drop --help```
 
-- See the "parent" options: ```./drop --help```
-
-- See different commands for ```-f```: ```./drop -c```
-
-- See "child" options for the different commands: ```./drop -f [command string from -c] --help```
+- See command options: ```./drop [command] --help```
 
 After compilation, you can export the path to the DROP executable to use the tool without the ```./```.
 
@@ -32,15 +27,11 @@ After compilation, you can export the path to the DROP executable to use the too
 
 To measure the dihedral angles of a given structure, use ```measureDihedrals```. To manipulate protein structures, you can use ```setDihedral``` or ```setDihedralList```. The former allows for the modification of one dihedral angle and the latter allows the user to provide a list of dihedral angles in a file to change in the structure. First example for ```setDihedral```:
 
-```./drop -f setDihedral -i example_files/ILE_conect_110.pdb -n 2 -d phi -a -60 -o output.pdb```
+```./drop setDihedral -i example_files/ILE_conect_110.pdb -n 2 -d phi -a -60 -o output.pdb```
 
 which changes the dihedral angle phi of residue 2 to -60 degrees. You can visualize ```output.pdb``` with your favorite visualization tool like VMD or PyMol. ```setDihedralList``` has examples in ```examples/setDihedralList/README.md```, but here's an example command:
 
-```./drop -f setDihedralList -i examples/setDihedralList/Polyarginine/poly-R-beta.pdb -d examples/setDihedralList/Polyarginine/beta-to-helix.txt -o poly-R-helix.pdb```
-
-### Known Issues
-
-- "Parent" option ```-f``` or ```-c``` must come first after the executable. See Issue #10 for more details.
+```./drop setDihedralList -i examples/setDihedralList/Polyarginine/poly-R-beta.pdb -d examples/setDihedralList/Polyarginine/beta-to-helix.txt -o poly-R-helix.pdb```
 
 ### Citation
 

--- a/examples/setDihedralList/README.md
+++ b/examples/setDihedralList/README.md
@@ -10,7 +10,7 @@ First, let's take a 5-mer polyarginine in a beta sheet configuration and convert
 
 ![polyRbeta](Polyarginine/poly-R-beta.png)
 
-Then we will run the following command from the parent directory: ```./drop -f setDihedralList -i examples/setDihedralList/Polyarginine/poly-R-beta.pdb -d examples/setDihedralList/Polyarginine/beta-to-helix.txt -o poly-R-helix.pdb```
+Then we will run the following command from the parent directory: ```./drop setDihedralList -i examples/setDihedralList/Polyarginine/poly-R-beta.pdb -d examples/setDihedralList/Polyarginine/beta-to-helix.txt -o poly-R-helix.pdb```
 
 Here is a visualization of ```Polyarginine/poly-R-helix.pdb```:
 
@@ -18,7 +18,7 @@ Here is a visualization of ```Polyarginine/poly-R-helix.pdb```:
 
 Both images have the peptide oriented with the N-terminus and C-terminus at the top and bottom center, respectively. You can also do this with side chain torsions or combinations of backbone and side chain torsions in the file provided to ```-d```.
 
-As an example with side chain angles, you can run this command: ```./drop -f setDihedralList -i examples/setDihedralList/Polyarginine/poly-R-beta.pdb -d examples/setDihedralList/Polyarginine/side-chain.txt -o poly-R-beta-SC.pdb```
+As an example with side chain angles, you can run this command: ```./drop setDihedralList -i examples/setDihedralList/Polyarginine/poly-R-beta.pdb -d examples/setDihedralList/Polyarginine/side-chain.txt -o poly-R-beta-SC.pdb```
 
 Here is a visualization of (the broken) modified structure ```Polyarginine/poly-R-beta-SC.png```:
 

--- a/src/drop/commands.c
+++ b/src/drop/commands.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
 #include <argp.h>
@@ -48,22 +47,11 @@ printCommandList ()
 	}
 }
 
-//assigns all of argv to the null terminator
-void
-stripAllArgv (int argc, char **argv)
-{
-  for (int i = 0; i < argc; i++)
-	{
-	  argv[i] = "\0";
-	}
-}
-
 //makes a string of argv to print command line to log
 char *
 makeStringArgv (int argc, char **argv)
 {
-  char *strng;
-  strcpy (strng, argv[0]);
+  char *strng = argv[0];
   for (int i = 1; i < argc; i++)
 	{
 	  strcat (strng, " ");
@@ -75,9 +63,14 @@ makeStringArgv (int argc, char **argv)
 bool
 findCommand (char *func, int argc, char **argv)
 {
+  fprintf(stderr, "%s\n", func);
+  fprintf(stderr, "%d\n", strcmp(func, commandList[0][0]));
   bool found = true;
   //make a string of argv arguments for the log file output
   char *stringArgv = makeStringArgv (argc, argv);
+
+  fprintf(stderr, "erased?: %s\n", func);
+  fprintf(stderr, "%d\n", strcmp(func, commandList[0][0]));
 
   //search available commands or functions
   if (strcmp (func, commandList[0][0]) == 0)
@@ -109,7 +102,6 @@ findCommand (char *func, int argc, char **argv)
 	  found = false;
 	}
 
-  stripAllArgv (argc, argv);	//all argv is made the null terminator so parser will not throw an error passing back to main
   return found;
 
 }

--- a/src/drop/commands.c
+++ b/src/drop/commands.c
@@ -33,8 +33,8 @@ void
 printCommandList ()
 {
 
-  fprintf (stderr, "These are the commands available:\n\n");
-  fprintf (stderr, "EXAMPLE > #: function - description -\n\n");
+  fprintf (stderr, "These are the commands available:\n");
+  fprintf (stderr, "EXAMPLE > #: function - description -\n");
 
   for (int i = 0; i < commandListLen; i++)
 	{
@@ -43,7 +43,7 @@ printCommandList ()
 		{
 		  fprintf (stderr, "%s - ", commandList[i][j]);
 		}
-	  fprintf (stderr, "\n\n");
+	  fprintf (stderr, "\n");
 	}
 }
 

--- a/src/drop/commands.c
+++ b/src/drop/commands.c
@@ -47,55 +47,35 @@ printCommandList ()
 	}
 }
 
-//makes a string of argv to print command line to log
-char *
-makeStringArgv (int argc, char **argv)
-{
-  char *strng = argv[0];
-  for (int i = 1; i < argc; i++)
-	{
-	  strcat (strng, " ");
-	  strcat (strng, argv[i]);
-	}
-  return strng;
-}
-
 bool
-findCommand (char *func, int argc, char **argv)
+findCommand (int argc, char **argv)
 {
-  fprintf(stderr, "%s\n", func);
-  fprintf(stderr, "%d\n", strcmp(func, commandList[0][0]));
   bool found = true;
-  //make a string of argv arguments for the log file output
-  char *stringArgv = makeStringArgv (argc, argv);
-
-  fprintf(stderr, "erased?: %s\n", func);
-  fprintf(stderr, "%d\n", strcmp(func, commandList[0][0]));
 
   //search available commands or functions
-  if (strcmp (func, commandList[0][0]) == 0)
+  if (strcmp (argv[1], commandList[0][0]) == 0)
 	{
-	  measureDihedrals (argc, argv, stringArgv);
+	  measureDihedrals (argc, argv);
 	}
-  else if (strcmp (func, commandList[1][0]) == 0)
+  else if (strcmp (argv[1], commandList[1][0]) == 0)
 	{
-	  setDihedral (argc, argv, stringArgv);
+	  setDihedral (argc, argv);
 	}
-  else if (strcmp (func, commandList[2][0]) == 0)
+  else if (strcmp (argv[1], commandList[2][0]) == 0)
 	{
-	  setDihedralList (argc, argv, stringArgv);
+	  setDihedralList (argc, argv);
 	}
-  else if (strcmp (func, commandList[3][0]) == 0)
+  else if (strcmp (argv[1], commandList[3][0]) == 0)
 	{
-	  stericClashes (argc, argv, stringArgv);
+	  stericClashes (argc, argv);
 	}
-  else if (strcmp (func, commandList[4][0]) == 0)
+  else if (strcmp (argv[1], commandList[4][0]) == 0)
 	{
-	  stericScan (argc, argv, stringArgv);
+	  stericScan (argc, argv);
 	}
-  else if (strcmp (func, commandList[5][0]) == 0)
+  else if (strcmp (argv[1], commandList[5][0]) == 0)
 	{
-	  vdwScan (argc, argv, stringArgv);
+	  vdwScan (argc, argv);
 	}
   else
 	{

--- a/src/drop/commands.h
+++ b/src/drop/commands.h
@@ -5,7 +5,7 @@ extern const char *commandList[][2];	/* list of commands and descriptions */
 extern const int commandListLen;	/* number of commands */
 
 void printCommandList ();
-bool findCommand (char *arg, int argc, char **argv);
+bool findCommand (char *func, int argc, char **argv);
 void stripFArgv (int argc, char **argv);
 void stripAllArgv (int argc, char **argv);
 char *makeStringArgv (int argc, char **argv);

--- a/src/drop/commands.h
+++ b/src/drop/commands.h
@@ -5,9 +5,6 @@ extern const char *commandList[][2];	/* list of commands and descriptions */
 extern const int commandListLen;	/* number of commands */
 
 void printCommandList ();
-bool findCommand (char *func, int argc, char **argv);
-void stripFArgv (int argc, char **argv);
-void stripAllArgv (int argc, char **argv);
-char *makeStringArgv (int argc, char **argv);
+bool findCommand (int argc, char **argv);
 
 #endif

--- a/src/drop/drop.c
+++ b/src/drop/drop.c
@@ -14,7 +14,6 @@ static char doc[] =
 int
 main (int argc, char *argv[])
 {
-  fprintf(stderr, "%s\n", argv[1]);
   if (strcmp(argv[1], "-?") == 0 || strcmp(argv[1], "--help") == 0)
       {
           fprintf(stderr, "this is the help message\n");
@@ -25,7 +24,7 @@ main (int argc, char *argv[])
       }
   else
   {
-      if (!findCommand (argv[1], argc, argv))
+      if (!findCommand (argc, argv))
           {
               fprintf(stderr, "Command %s not recognized.\n", argv[1]);
               //print usage

--- a/src/drop/drop.c
+++ b/src/drop/drop.c
@@ -5,6 +5,7 @@
 
 #include "commands.h"
 
+const char *usage_messg = "USAGE: drop command [OPTIONS]. Use drop -? or drop --help for more information.\n";
 const char *program_bug_address =
   "https://github.com/andrewsb8/DROP/issues";
 const char *program_version = "DROP Version 0.0.1";
@@ -16,11 +17,14 @@ main (int argc, char *argv[])
 {
   if (argc < 2)
       {
-          fprintf(stderr, "usage message\n");
+          fprintf(stderr, "%s", usage_messg);
       }
   else if (strcmp(argv[1], "-?") == 0 || strcmp(argv[1], "--help") == 0)
       {
-          fprintf(stderr, "this is the help message\n");
+          fprintf(stderr, "Welcome to %s\n", program_version);
+          printCommandList();
+          fprintf(stderr, "Use drop command -? for more information.\n");
+          fprintf(stderr, "Report bugs to: %s\n", program_bug_address);
       }
   else if (strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0)
       {
@@ -31,7 +35,7 @@ main (int argc, char *argv[])
       if (!findCommand (argc, argv))
           {
               fprintf(stderr, "Command %s not recognized.\n", argv[1]);
-              //print usage
+              fprintf(stderr, "%s", usage_messg);
           }
   }
   return 0;

--- a/src/drop/drop.c
+++ b/src/drop/drop.c
@@ -5,82 +5,31 @@
 
 #include "commands.h"
 
-const char *argp_program_bug_address =
+const char *program_bug_address =
   "https://github.com/andrewsb8/DROP/issues";
-const char *argp_program_version = "DROP Version 0.0.1";
+const char *program_version = "DROP Version 0.0.1";
 static char doc[] =
-  "DROP (Dihedral Rotation Of Proteins) -- A tool to investigate protein structures via direct manipulation of dihedral angles and steric clash analysis.";
-
-int num_master_options_read = 0;
-
-static int
-parse_opt (int key, char *arg, struct argp_state *state)
-{
-  //only allow one "parent" option, -f or -c, to be executed at a time
-  if (num_master_options_read == 0)
-	{
-	  switch (key)
-		{
-		  //function definition case
-		case 'f':
-		  {
-			//NULL case is handled by requiring -f in struct argp_option
-			if (!findCommand (arg, state->argc, state->argv))
-			  {
-				fprintf (stderr,
-						 "This is not an option for -f. See argp -c for details.\n");
-				argp_usage (state);
-			  }
-			num_master_options_read++;
-			break;
-		  }
-
-		  //print list of available commands
-		case 'c':
-		  {
-			if ((arg == NULL))
-			  {
-				printCommandList ();
-			  }
-			else				//block currently does not execute
-			  {
-				fprintf (stderr,
-						 "This option does not accept an argument.\n");
-				argp_usage (state);
-			  }
-			num_master_options_read++;
-			break;
-		  }
-
-		case ARGP_KEY_END:
-		  {
-			// Not enough arguments.
-			if (state->arg_num < 2)
-			  {
-				fprintf (stderr, "No arguments provided.\n");
-				argp_usage (state);
-			  }
-			break;
-		  }
-		}
-	}
-  return 0;
-}
+  "DROP (Dihedral Rotation Of Proteins) -- A command line tool to investigate protein structures via direct manipulation of dihedral angles.";
 
 int
 main (int argc, char *argv[])
 {
-  static struct argp_option options[] = {
-	{"func", 'f', "[Function String]", 0,
-	 "Identify Function. Must be first option specified!"},
-	{"commands", 'c', 0, OPTION_ARG_OPTIONAL, "See options for -f"},
-	{0, 0, 0, 0,
-	 "To see options for a specific function: ./drop -f [FUNC] --help"},
-	{0, 0, 0, 0, "Informational Options:"},
-	{0}
-  };
-
-  struct argp argp = { options, parse_opt, 0, 0 };
-
-  return argp_parse (&argp, argc, argv, 0, 0, 0);
+  fprintf(stderr, "%s\n", argv[1]);
+  if (strcmp(argv[1], "-?") == 0 || strcmp(argv[1], "--help") == 0)
+      {
+          fprintf(stderr, "this is the help message\n");
+      }
+  else if (strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0)
+      {
+          fprintf(stderr, "%s\n", program_version);
+      }
+  else
+  {
+      if (!findCommand (argv[1], argc, argv))
+          {
+              fprintf(stderr, "Command %s not recognized.\n", argv[1]);
+              //print usage
+          }
+  }
+  return 0;
 }

--- a/src/drop/drop.c
+++ b/src/drop/drop.c
@@ -14,7 +14,11 @@ static char doc[] =
 int
 main (int argc, char *argv[])
 {
-  if (strcmp(argv[1], "-?") == 0 || strcmp(argv[1], "--help") == 0)
+  if (argc < 2)
+      {
+          fprintf(stderr, "usage message\n");
+      }
+  else if (strcmp(argv[1], "-?") == 0 || strcmp(argv[1], "--help") == 0)
       {
           fprintf(stderr, "this is the help message\n");
       }

--- a/src/dropanalysis/measureDihedrals.c
+++ b/src/dropanalysis/measureDihedrals.c
@@ -55,14 +55,13 @@ void
 measureDihedrals (int argc, char **argv)
 {
   struct argp_option measureDihedralsOptions[] = {
-	{0, 0, 0, 0, "./drop -f measureDihedrals Options:\n"},
+	{0, 0, 0, 0, "./drop measureDihedrals Options:\n"},
 	{"input", 'i', "[Input File]", 0, "Input pdb file"},
 	{"log", 'l', "[Log File]", 0, "Output log file"},
 	{"bond_matrix", 'b', "[Boolean]", 0,
 	 "Choose whether or not to print bond matrix to log file. Default: true"},
 	{"dihedral_list", 'd', "[Output File]", 0,
 	 "Optional output file name to print the dihedral information to a file that can be modified and used as an input file for setDihedralList."},
-	{"", 'f', "", OPTION_HIDDEN, ""},	//gets rid of error for -f flag
 	{0}
   };
 

--- a/src/dropanalysis/measureDihedrals.c
+++ b/src/dropanalysis/measureDihedrals.c
@@ -73,6 +73,8 @@ measureDihedrals (int argc, char **argv)
 	{ measureDihedralsOptions, measureDihedralsParse, 0, 0 };
   argp_parse (&measureDihedralsArgp, argc, argv, 0, 0, &args);
 
+  fprintf(stderr, "%s\n", args.input_file);
+
   struct protein prot;
   FILE *log = fopen (args.log_file, "w");
   processInput (&prot, args.input_file, log, 0, 0, argc, argv);

--- a/src/dropanalysis/measureDihedrals.c
+++ b/src/dropanalysis/measureDihedrals.c
@@ -52,7 +52,7 @@ measureDihedralsParse (int key, char *arg, struct argp_state *state)
 }
 
 void
-measureDihedrals (int argc, char **argv, char *stringArgv)
+measureDihedrals (int argc, char **argv)
 {
   struct argp_option measureDihedralsOptions[] = {
 	{0, 0, 0, 0, "./drop -f measureDihedrals Options:\n"},
@@ -75,7 +75,7 @@ measureDihedrals (int argc, char **argv, char *stringArgv)
 
   struct protein prot;
   FILE *log = fopen (args.log_file, "w");
-  processInput (&prot, args.input_file, log, 0, 0, stringArgv);
+  processInput (&prot, args.input_file, log, 0, 0, argc, argv);
 
   if (args.dihedral_list)
 	{

--- a/src/dropanalysis/measureDihedrals.h
+++ b/src/dropanalysis/measureDihedrals.h
@@ -3,6 +3,6 @@
 
 static int measureDihedralsParse (int key, char *arg,
 								  struct argp_state *state);
-void measureDihedrals (int argc, char **argv, char *stringArgv);
+void measureDihedrals (int argc, char **argv);
 
 #endif

--- a/src/dropanalysis/setDihedral.c
+++ b/src/dropanalysis/setDihedral.c
@@ -87,7 +87,7 @@ void
 setDihedral (int argc, char **argv)
 {
   struct argp_option setDihedralOptions[] = {
-	{0, 0, 0, 0, "./drop -f setDihedral Options:\n"},
+	{0, 0, 0, 0, "./drop setDihedral Options:\n"},
 	{"input", 'i', "[Input File]", 0, "Input pdb file"},
 	{"output", 'o', "[Output File]", 0,
 	 "Output file. Options: see -e for options."},
@@ -101,7 +101,6 @@ setDihedral (int argc, char **argv)
 	 "Include CONECT records in PDB. 0 does not print conect. Default: 0."},
 	{"bond_matrix", 'b', "[Boolean]", 0,
 	 "Choose whether or not to print bond matrix to log file. Default: true"},
-	{"", 'f', "", OPTION_HIDDEN, ""},	//gets rid of error for -f flag
 	{0}
   };
 

--- a/src/dropanalysis/setDihedral.c
+++ b/src/dropanalysis/setDihedral.c
@@ -84,7 +84,7 @@ setDihedralParse (int key, char *arg, struct argp_state *state)
 }
 
 void
-setDihedral (int argc, char **argv, char *stringArgv)
+setDihedral (int argc, char **argv)
 {
   struct argp_option setDihedralOptions[] = {
 	{0, 0, 0, 0, "./drop -f setDihedral Options:\n"},
@@ -115,7 +115,7 @@ setDihedral (int argc, char **argv, char *stringArgv)
 
   struct protein prot;
   FILE *log = fopen (args.log_file, "w");
-  processInput (&prot, args.input_file, log, 0, 0, stringArgv);
+  processInput (&prot, args.input_file, log, 0, 0, argc, argv);
 
   //find dihedral to change based on user input
   int index = findDihedral (&prot, args.res_number, args.dih_type);

--- a/src/dropanalysis/setDihedral.h
+++ b/src/dropanalysis/setDihedral.h
@@ -2,6 +2,6 @@
 #define SETDIHEDRAL_H_
 
 static int setDihedralParse (int key, char *arg, struct argp_state *state);
-void setDihedral (int argc, char **argv, char *stringArgv);
+void setDihedral (int argc, char **argv);
 
 #endif

--- a/src/dropanalysis/setDihedralList.c
+++ b/src/dropanalysis/setDihedralList.c
@@ -72,7 +72,7 @@ setDihedralListParse (int key, char *arg, struct argp_state *state)
 }
 
 void
-setDihedralList (int argc, char **argv, char *stringArgv)
+setDihedralList (int argc, char **argv)
 {
   struct argp_option setDihedralListOptions[] = {
 	{0, 0, 0, 0, "./drop -f setDihedralList Options:\n"},
@@ -108,7 +108,7 @@ setDihedralList (int argc, char **argv, char *stringArgv)
 
   struct protein prot;
   FILE *log = fopen (args.log_file, "w");
-  processInput (&prot, args.input_file, log, 0, 0, stringArgv);
+  processInput (&prot, args.input_file, log, 0, 0, argc, argv);
 
   fprintf (log, "Starting structure manipulation from dihedral list: %s\n",
 		   args.input_dih_list);

--- a/src/dropanalysis/setDihedralList.c
+++ b/src/dropanalysis/setDihedralList.c
@@ -75,7 +75,7 @@ void
 setDihedralList (int argc, char **argv)
 {
   struct argp_option setDihedralListOptions[] = {
-	{0, 0, 0, 0, "./drop -f setDihedralList Options:\n"},
+	{0, 0, 0, 0, "./drop setDihedralList Options:\n"},
 	{"input", 'i', "[Input File]", 0, "Input pdb file"},
 	{"input_dih_list", 'd', "[Input Dihedral List File]", 0,
 	 "Input pdb file"},
@@ -87,7 +87,6 @@ setDihedralList (int argc, char **argv)
 	 "Include CONECT records in PDB. 0 does not print conect. Default: 0."},
 	{"bond_matrix", 'b', "[Boolean]", 0,
 	 "Choose whether or not to print bond matrix to log file. Default: true"},
-	{"", 'f', "", OPTION_HIDDEN, ""},	//gets rid of error for -f flag
 	{0}
   };
 

--- a/src/dropanalysis/setDihedralList.h
+++ b/src/dropanalysis/setDihedralList.h
@@ -3,6 +3,6 @@
 
 static int setDihedralListParse (int key, char *arg,
 								 struct argp_state *state);
-void setDihedralList (int argc, char **argv, char *stringArgv);
+void setDihedralList (int argc, char **argv);
 
 #endif

--- a/src/dropanalysis/stericClashes.c
+++ b/src/dropanalysis/stericClashes.c
@@ -48,7 +48,7 @@ stericClashesParse (int key, char *arg, struct argp_state *state)
 }
 
 void
-stericClashes (int argc, char **argv, char *stringArgv)
+stericClashes (int argc, char **argv)
 {
   struct argp_option stericClashesOptions[] = {
 	{0, 0, 0, 0, "./drop -f stericClashes Options:\n"},
@@ -71,7 +71,7 @@ stericClashes (int argc, char **argv, char *stringArgv)
 
   struct protein prot;
   FILE *log = fopen (args.log_file, "w");
-  processInput (&prot, args.input_file, log, 1, args.bond_matrix, stringArgv);
+  processInput (&prot, args.input_file, log, 1, args.bond_matrix, argc, argv);
 
   if (!args.list_clashes)
 	{

--- a/src/dropanalysis/stericClashes.c
+++ b/src/dropanalysis/stericClashes.c
@@ -51,14 +51,13 @@ void
 stericClashes (int argc, char **argv)
 {
   struct argp_option stericClashesOptions[] = {
-	{0, 0, 0, 0, "./drop -f stericClashes Options:\n"},
+	{0, 0, 0, 0, "./drop stericClashes Options:\n"},
 	{"input", 'i', "[Input File]", 0, "Input pdb file"},
 	{"log", 'l', "[Log File]", 0, "Output log file"},
 	{"bond_matrix", 'b', "[Boolean]", 0,
 	 "Choose whether or not to print bond matrix. Default: true"},
 	{"list_clashes", 'c', "[Boolean]", 0,
 	 "Choose to list atomic clashes in log file. 0 does not print list. Default: 1."},
-	{"", 'f', "", OPTION_HIDDEN, ""},	//gets rid of error for -f flag
 	{0}
   };
 

--- a/src/dropanalysis/stericClashes.h
+++ b/src/dropanalysis/stericClashes.h
@@ -2,6 +2,6 @@
 #define STERICCLASHES_H_
 
 static int stericClashesParse (int key, char *arg, struct argp_state *state);
-void stericClashes (int argc, char **argv, char *stringArgv);
+void stericClashes (int argc, char **argv);
 
 #endif

--- a/src/dropanalysis/stericScan.c
+++ b/src/dropanalysis/stericScan.c
@@ -70,7 +70,7 @@ void
 stericScan (int argc, char **argv)
 {
   struct argp_option stericScanOptions[] = {
-	{0, 0, 0, 0, "./drop -f stericScan Options:\n"},
+	{0, 0, 0, 0, "./drop stericScan Options:\n"},
 	{"input", 'i', "[Input File]", 0, "Input pdb file"},
 	{"output", 'o', "[Output File]", 0,
 	 "Output .txt file with three columns: phi, psi, average number of clashes."},
@@ -81,7 +81,6 @@ stericScan (int argc, char **argv)
 	 "Resolution of Ramachandran space (and therefore dihedral rotation magnitude). Default: 2 deg"},
 	{"bond_matrix", 'b', "[Boolean]", 0,
 	 "Choose whether or not to print bond matrix to log file. Default: true"},
-	{"", 'f', "", OPTION_HIDDEN, ""},	//gets rid of error for -f flag
 	{0}
   };
 

--- a/src/dropanalysis/stericScan.c
+++ b/src/dropanalysis/stericScan.c
@@ -67,7 +67,7 @@ stericScanParse (int key, char *arg, struct argp_state *state)
 }
 
 void
-stericScan (int argc, char **argv, char *stringArgv)
+stericScan (int argc, char **argv)
 {
   struct argp_option stericScanOptions[] = {
 	{0, 0, 0, 0, "./drop -f stericScan Options:\n"},
@@ -93,7 +93,7 @@ stericScan (int argc, char **argv, char *stringArgv)
 
   struct protein prot;
   FILE *log = fopen (args.log_file, "w");
-  processInput (&prot, args.input_file, log, 1, args.bond_matrix, stringArgv);
+  processInput (&prot, args.input_file, log, 1, args.bond_matrix, argc, argv);
 
   //array -> [phi index, psi index, chi1 index, ..., chi5 index]
   //value is -1 for any dihedral not detected

--- a/src/dropanalysis/stericScan.h
+++ b/src/dropanalysis/stericScan.h
@@ -2,6 +2,6 @@
 #define STERICSCAN_H_
 
 static int stericScanParse (int key, char *arg, struct argp_state *state);
-void stericScan (int argc, char **argv, char *stringArgv);
+void stericScan (int argc, char **argv);
 
 #endif

--- a/src/dropanalysis/vdwScan.c
+++ b/src/dropanalysis/vdwScan.c
@@ -74,7 +74,7 @@ vdwScanParse (int key, char *arg, struct argp_state *state)
 }
 
 void
-vdwScan (int argc, char **argv, char *stringArgv)
+vdwScan (int argc, char **argv)
 {
   struct argp_option vdwScanOptions[] = {
 	{0, 0, 0, 0, "./drop -f stericScan Options:\n"},
@@ -102,7 +102,7 @@ vdwScan (int argc, char **argv, char *stringArgv)
 
   struct protein prot;
   FILE *log = fopen (args.log_file, "w");
-  processInput (&prot, args.input_file, log, 1, args.bond_matrix, stringArgv);
+  processInput (&prot, args.input_file, log, 1, args.bond_matrix, argc, argv);
 
   //array -> [phi index, psi index, chi1 index, ..., chi5 index]
   //value is -1 for any dihedral not detected

--- a/src/dropanalysis/vdwScan.c
+++ b/src/dropanalysis/vdwScan.c
@@ -77,7 +77,7 @@ void
 vdwScan (int argc, char **argv)
 {
   struct argp_option vdwScanOptions[] = {
-	{0, 0, 0, 0, "./drop -f stericScan Options:\n"},
+	{0, 0, 0, 0, "./drop stericScan Options:\n"},
 	{"input", 'i', "[Input File]", 0, "Input pdb file"},
 	{"output", 'o', "[Output File]", 0,
 	 "Output .txt file with three columns: phi, psi, average Lennard-Jones energy in kJ/mol"},
@@ -90,7 +90,6 @@ vdwScan (int argc, char **argv)
 	 "Choose whether or not to print bond matrix to log file. Default: true"},
 	{"gamma", 'g', "[Boolean]", 0,
 	 "Factor for cutoff for allowed states based on steric cutoffs. Default: 1.0"},
-	{"", 'f', "", OPTION_HIDDEN, ""},	//gets rid of error for -f flag
 	{0}
   };
 

--- a/src/dropanalysis/vdwScan.h
+++ b/src/dropanalysis/vdwScan.h
@@ -2,6 +2,6 @@
 #define VDWSCAN_H_
 
 static int vdwScanParse (int key, char *arg, struct argp_state *state);
-void vdwScan (int argc, char **argv, char *stringArgv);
+void vdwScan (int argc, char **argv);
 
 #endif

--- a/src/utils/fileHandling/fileHandling.c
+++ b/src/utils/fileHandling/fileHandling.c
@@ -12,17 +12,16 @@ fileExists (char *filename)
   return access (filename, F_OK);
 }
 
-//makes a string of argv to print command line to log
-char *
-makeStringArgv (int argc, char **argv)
+void
+printArgv (FILE * log, int argc, char **argv)
 {
-  char *strng = argv[0];
-  for (int i = 1; i < argc; i++)
+  fprintf(log, "Command line: ");
+  for (int i = 0; i < argc; i++)
 	{
-	  strcat (strng, " ");
-	  strcat (strng, argv[i]);
+	  fprintf(log, "%s ", argv[i]);
 	}
-  return strng;
+  fprintf(log, "\n\n");
+  return;
 }
 
 void
@@ -30,8 +29,7 @@ processInput (struct protein *prot, char *input_file, FILE * log,
 			  bool calc_bond_matrix, bool print_bond_matrix, int argc, char **argv)
 {
   //make a string of argv arguments for the log file output
-  char *stringArgv = makeStringArgv (argc, argv);
-  fprintf (log, "Command Line: %s\n\n", stringArgv);
+  printArgv (log, argc, argv);
   if (fileExists (input_file) == -1)
 	{
 	  drop_fatal (log, "ERROR: Input file does not exist. Exiting.\n");

--- a/src/utils/fileHandling/fileHandling.c
+++ b/src/utils/fileHandling/fileHandling.c
@@ -15,8 +15,9 @@ fileExists (char *filename)
 void
 printArgv (FILE * log, int argc, char **argv)
 {
-  fprintf(log, "Command line: ");
-  for (int i = 0; i < argc; i++)
+  //argp puts command at end of argv after parsing
+  fprintf(log, "Command line: %s %s ", argv[0], argv[argc-1]);
+  for (int i = 1; i < argc-1; i++)
 	{
 	  fprintf(log, "%s ", argv[i]);
 	}

--- a/src/utils/fileHandling/fileHandling.c
+++ b/src/utils/fileHandling/fileHandling.c
@@ -12,10 +12,25 @@ fileExists (char *filename)
   return access (filename, F_OK);
 }
 
+//makes a string of argv to print command line to log
+char *
+makeStringArgv (int argc, char **argv)
+{
+  char *strng = argv[0];
+  for (int i = 1; i < argc; i++)
+	{
+	  strcat (strng, " ");
+	  strcat (strng, argv[i]);
+	}
+  return strng;
+}
+
 void
 processInput (struct protein *prot, char *input_file, FILE * log,
-			  bool calc_bond_matrix, bool print_bond_matrix, char *stringArgv)
+			  bool calc_bond_matrix, bool print_bond_matrix, int argc, char **argv)
 {
+  //make a string of argv arguments for the log file output
+  char *stringArgv = makeStringArgv (argc, argv);
   fprintf (log, "Command Line: %s\n\n", stringArgv);
   if (fileExists (input_file) == -1)
 	{

--- a/src/utils/fileHandling/fileHandling.h
+++ b/src/utils/fileHandling/fileHandling.h
@@ -5,7 +5,7 @@ int fileExists (char *filename);
 void processInput (struct protein *prot, char *input_file, FILE * log,
 				   bool calc_bond_matrix, bool print_bond_matrix,
 				   int argc, char **argv);
-char *makeStringArgv (int argc, char **argv);
+void printArgv (FILE * log, int argc, char **argv);
 void writeFileLine (FILE * file, char *message);
 
 #endif

--- a/src/utils/fileHandling/fileHandling.h
+++ b/src/utils/fileHandling/fileHandling.h
@@ -4,7 +4,8 @@
 int fileExists (char *filename);
 void processInput (struct protein *prot, char *input_file, FILE * log,
 				   bool calc_bond_matrix, bool print_bond_matrix,
-				   char *stringArgv);
+				   int argc, char **argv);
+char *makeStringArgv (int argc, char **argv);
 void writeFileLine (FILE * file, char *message);
 
 #endif


### PR DESCRIPTION
Resolves #10.

Removes top level of argp and uses custom help and usage messages. Removes the ```-f``` option entirely so that the command coming first is not an issue. Removes specific hacky functions like ```stripArgv``` to avoid argp errors. ```drop.c``` is much simpler this way.