### PR TITLE
Change cutoff

### DIFF
--- a/src/dropanalysis/vdwScan.c
+++ b/src/dropanalysis/vdwScan.c
@@ -88,7 +88,7 @@ void vdwScan(int argc, char **argv)
 		{ "bond_matrix", 'b', "[Boolean]", 0,
 		 "Choose whether or not to print bond matrix to log file. Default: true"
 		 },
-		{ "gamma", 'g', "[Boolean]", 0,
+		{ "gamma", 'g', "[Float]", 0,
 		 "Factor for cutoff for allowed states based on steric cutoffs. Default: 1.0"
 		 },
 		{ 0 }

--- a/src/utils/dihedralRotation/dihedralRotation.c
+++ b/src/utils/dihedralRotation/dihedralRotation.c
@@ -19,24 +19,30 @@ double calculateDihedral(struct protein *prot, int dihedralNumber)
 
 	double *vec1 =
 		vectorSubtract(prot->atoms
-					   [prot->dihedrals[dihedralNumber].
-						dihedral_atomNumbers[0] - 1].coordinates,
-					   prot->atoms[prot->dihedrals[dihedralNumber].
-								   dihedral_atomNumbers[1]
+					   [prot->
+						dihedrals[dihedralNumber].dihedral_atomNumbers[0] -
+						1].coordinates,
+					   prot->atoms[prot->
+								   dihedrals
+								   [dihedralNumber].dihedral_atomNumbers[1]
 								   - 1].coordinates);
 	double *vec2 =
 		vectorSubtract(prot->atoms
-					   [prot->dihedrals[dihedralNumber].
-						dihedral_atomNumbers[1] - 1].coordinates,
-					   prot->atoms[prot->dihedrals[dihedralNumber].
-								   dihedral_atomNumbers[2]
+					   [prot->
+						dihedrals[dihedralNumber].dihedral_atomNumbers[1] -
+						1].coordinates,
+					   prot->atoms[prot->
+								   dihedrals
+								   [dihedralNumber].dihedral_atomNumbers[2]
 								   - 1].coordinates);
 	double *vec3 =
 		vectorSubtract(prot->atoms
-					   [prot->dihedrals[dihedralNumber].
-						dihedral_atomNumbers[2] - 1].coordinates,
-					   prot->atoms[prot->dihedrals[dihedralNumber].
-								   dihedral_atomNumbers[3]
+					   [prot->
+						dihedrals[dihedralNumber].dihedral_atomNumbers[2] -
+						1].coordinates,
+					   prot->atoms[prot->
+								   dihedrals
+								   [dihedralNumber].dihedral_atomNumbers[3]
 								   - 1].coordinates);
 
 	double *cross1 = crossProduct(vec1, vec2);
@@ -182,9 +188,8 @@ rotateDihedral(struct protein *prot, int dihedralNumber,
 
 		for (int k = 0;
 			 k <
-			 prot->residues[prot->
-							dihedrals[dihedralNumber].dihedral_resNum -
-							1].num_sc_atoms; k++) {
+			 prot->residues[prot->dihedrals[dihedralNumber].
+							dihedral_resNum - 1].num_sc_atoms; k++) {
 			//residue/dihedral is identified by third atom in dihedral, consistent with readProtein.c
 			if (prot->dihedrals[dihedralNumber].dihedral_atomNumbers[2] ==
 				prot->residues[prot->dihedrals
@@ -203,9 +208,9 @@ rotateDihedral(struct protein *prot, int dihedralNumber,
 								 (M_PI / 180.0) * dihedralAngleChange);
 				updatePositions(prot, tmp,
 								prot->residues[prot->dihedrals
-											   [dihedralNumber].
-											   dihedral_resNum -
-											   1].sidechain_atoms[k] - 1);
+											   [dihedralNumber].dihedral_resNum
+											   - 1].sidechain_atoms[k] -
+								1);
 				free(tmp);
 			}
 		}

--- a/src/utils/fileHandling/fileHandling.c
+++ b/src/utils/fileHandling/fileHandling.c
@@ -16,7 +16,7 @@ processInput(struct protein *prot, char *input_file, FILE * log,
 			 bool calc_bond_matrix, bool print_bond_matrix, int argc,
 			 char **argv)
 {
-    logWelcome(log);
+	logWelcome(log);
 	//make a string of argv arguments for the log file output
 	logArgv(log, argc, argv);
 	if (fileExists(input_file) == -1) {

--- a/src/utils/logging/logging.c
+++ b/src/utils/logging/logging.c
@@ -7,10 +7,10 @@
 
 void logWelcome(FILE * log)
 {
-    fprintf(log, "%s - %s\n", program_name, program_version);
+	fprintf(log, "%s - %s\n", program_name, program_version);
 	fprintf(log, "%s\n", program_desc);
 	fprintf(log, "Report bugs to: %s\n\n", program_bug_address);
-    fflush(log);
+	fflush(log);
 }
 
 void logArgv(FILE * log, int argc, char **argv)

--- a/src/utils/readProtein/readProtein.c
+++ b/src/utils/readProtein/readProtein.c
@@ -472,8 +472,8 @@ void identifyDihedrals(struct protein *prot)
 						 prot->atoms[prot->bonds[p].bond_atomNumbers[0]
 									 - 1].atom_type) == 0
 						&& strcmp(DihedralDefinitions[m][3],
-								  prot->atoms[prot->bonds[p].
-											  bond_atomNumbers[1]
+								  prot->atoms[prot->
+											  bonds[p].bond_atomNumbers[1]
 											  - 1].atom_type) == 0) {
 						pairTwo_index = p;
 						//multiple other bonds satisfy the above condition. Need to check for bond between the two pairs of bonds
@@ -486,41 +486,45 @@ void identifyDihedrals(struct protein *prot)
 								[pairTwo_index].bond_atomNumbers[0]
 								== prot->bonds[r].bond_atomNumbers[1]) {
 								prot->dihedrals
-									[prot->number_of_dihedrals].
-									dihedral_atomNumbers[0] =
+									[prot->
+									 number_of_dihedrals].dihedral_atomNumbers
+									[0] =
 									prot->bonds[n].bond_atomNumbers[0];
-								prot->dihedrals[prot->number_of_dihedrals].
-									dihedral_atomNumbers[1] =
+								prot->dihedrals[prot->
+												number_of_dihedrals].dihedral_atomNumbers
+									[1] =
 									prot->bonds[n].bond_atomNumbers[1];
-								prot->dihedrals[prot->number_of_dihedrals].
-									dihedral_atomNumbers[2] =
+								prot->dihedrals[prot->
+												number_of_dihedrals].dihedral_atomNumbers
+									[2] =
 									prot->bonds[p].bond_atomNumbers[0];
-								prot->dihedrals[prot->number_of_dihedrals].
-									dihedral_atomNumbers[3] =
+								prot->dihedrals[prot->
+												number_of_dihedrals].dihedral_atomNumbers
+									[3] =
 									prot->bonds[p].bond_atomNumbers[1];
 
 								*prot->dihedrals
-									[prot->number_of_dihedrals].
-									dihedral_angType =
-									DihedralDefinitions[m][4];
+									[prot->
+									 number_of_dihedrals].dihedral_angType
+									= DihedralDefinitions[m][4];
 
 								//residue is identified by third atom in dihedral because that will always be in the ith residue. Could have used second atom also.
 								//this will not work if omega is to be incorporated. but currently no plans to do so.
 								*prot->dihedrals
-									[prot->number_of_dihedrals].
-									dihedral_resName =
-									prot->atoms[prot->
-												dihedrals[prot->
-														  number_of_dihedrals].
-												dihedral_atomNumbers[2] -
-												1].residue;
-								prot->dihedrals[prot->number_of_dihedrals].
-									dihedral_resNum =
-									prot->atoms[prot->
-												dihedrals[prot->
-														  number_of_dihedrals].
-												dihedral_atomNumbers[2] -
-												1].residue_number;
+									[prot->
+									 number_of_dihedrals].dihedral_resName
+									=
+									prot->
+									atoms[prot->dihedrals
+										  [prot->number_of_dihedrals].dihedral_atomNumbers
+										  [2] - 1].residue;
+								prot->dihedrals[prot->
+												number_of_dihedrals].dihedral_resNum
+									=
+									prot->
+									atoms[prot->dihedrals
+										  [prot->number_of_dihedrals].dihedral_atomNumbers
+										  [2] - 1].residue_number;
 
 								prot->number_of_dihedrals += 1;
 								if (prot->number_of_dihedrals > 0) {

--- a/src/utils/stericClash/stericClash.c
+++ b/src/utils/stericClash/stericClash.c
@@ -13,7 +13,7 @@
 //Values:           C-C, C-O, C-N, C-H, O-O, O-N, O-H, N-N, N-H, H-H
 //struct VDW radii = {3.2, 2.8, 2.9, 2.4, 2.8, 2.7, 2.4, 2.7, 2.4, 2.0};
 //inner limit allowed via Ramachandran JMB 1963 in Angstroms
-struct VDW radii = { 3.0, 2.7, 2.8, 2.2, 2.7, 2.6, 2.2, 2.6, 2.2, 1.9 };
+struct stericRadii radii = { 3.0, 2.7, 2.8, 2.2, 2.7, 2.6, 2.2, 2.6, 2.2, 1.9 };
 
 int countClashes(struct protein *prot, FILE * log, bool list_clashes)
 {
@@ -35,7 +35,7 @@ int countClashes(struct protein *prot, FILE * log, bool list_clashes)
 								   prot->atoms[j].coordinates);
 				distance = vectorMagnitude(bond_vector);
 				free(bond_vector);
-				double min_distance_allowed = getVDWRadii(&radii,
+				double min_distance_allowed = getRadius(&radii,
 														  prot->
 														  atoms
 														  [i].atom_name,
@@ -61,7 +61,7 @@ int countClashes(struct protein *prot, FILE * log, bool list_clashes)
 	return count;
 }
 
-double getVDWRadii(struct VDW *radii, char *atom_name, char *atom_name_2)
+double getRadius(struct stericRadii *radii, char *atom_name, char *atom_name_2)
 {
 	switch (*atom_name) {
 	case 'N':

--- a/src/utils/stericClash/stericClash.c
+++ b/src/utils/stericClash/stericClash.c
@@ -13,7 +13,8 @@
 //Values:           C-C, C-O, C-N, C-H, O-O, O-N, O-H, N-N, N-H, H-H
 //struct VDW radii = {3.2, 2.8, 2.9, 2.4, 2.8, 2.7, 2.4, 2.7, 2.4, 2.0};
 //inner limit allowed via Ramachandran JMB 1963 in Angstroms
-struct stericRadii radii = { 3.0, 2.7, 2.8, 2.2, 2.7, 2.6, 2.2, 2.6, 2.2, 1.9 };
+struct stericRadii radii =
+	{ 3.0, 2.7, 2.8, 2.2, 2.7, 2.6, 2.2, 2.6, 2.2, 1.9 };
 
 int countClashes(struct protein *prot, FILE * log, bool list_clashes)
 {
@@ -36,12 +37,10 @@ int countClashes(struct protein *prot, FILE * log, bool list_clashes)
 				distance = vectorMagnitude(bond_vector);
 				free(bond_vector);
 				double min_distance_allowed = getRadius(&radii,
-														  prot->
-														  atoms
-														  [i].atom_name,
-														  prot->
-														  atoms
-														  [j].atom_name);
+														prot->atoms
+														[i].atom_name,
+														prot->atoms
+														[j].atom_name);
 				if (distance < min_distance_allowed) {
 					if (list_clashes) {
 						fprintf(log,
@@ -61,7 +60,8 @@ int countClashes(struct protein *prot, FILE * log, bool list_clashes)
 	return count;
 }
 
-double getRadius(struct stericRadii *radii, char *atom_name, char *atom_name_2)
+double getRadius(struct stericRadii *radii, char *atom_name,
+				 char *atom_name_2)
 {
 	switch (*atom_name) {
 	case 'N':

--- a/src/utils/stericClash/stericClash.h
+++ b/src/utils/stericClash/stericClash.h
@@ -18,6 +18,7 @@ struct stericRadii {
 };
 
 int countClashes(struct protein *prot, FILE * log, bool list_clashes);
-double getRadius(struct stericRadii *radii, char *atom_name, char *atom_name_2);
+double getRadius(struct stericRadii *radii, char *atom_name,
+				 char *atom_name_2);
 
 #endif

--- a/src/utils/stericClash/stericClash.h
+++ b/src/utils/stericClash/stericClash.h
@@ -1,7 +1,7 @@
 #ifndef STERICCLASH_H_
 #define STERICCLASH_H_
 
-struct VDW {
+struct stericRadii {
 	double CC;
 	double CO;
 	double CN;
@@ -17,9 +17,7 @@ struct VDW {
 	double HH;
 };
 
-extern struct VDW radii;
-
 int countClashes(struct protein *prot, FILE * log, bool list_clashes);
-double getVDWRadii(struct VDW *radii, char *atom_name, char *atom_name_2);
+double getRadius(struct stericRadii *radii, char *atom_name, char *atom_name_2);
 
 #endif

--- a/src/utils/vdwEnergy/vdwEnergy.c
+++ b/src/utils/vdwEnergy/vdwEnergy.c
@@ -7,7 +7,6 @@
 #include "../readProtein/readProtein.h"
 #include "vdwEnergy.h"
 #include "../vectorCalculus/vectorCalculus.h"
-#include "../stericClash/stericClash.h"
 
 //atom order: C, N, O, H
 //atom types from CHARMM36m: carbonyl C (peptide backbone), amide Nitrogen, carbonyl oxygen, nonpolar H
@@ -16,9 +15,6 @@ struct VDW_params sigma = { 3.56359, 3.29632, 3.02905, 2.35197 };
 
 //units: kJ/mol
 struct VDW_params epsilon = { 0.46024, 0.83680, 0.50208, 0.09204 };
-
-//copied from stericClash.c, inner radii for steric clashes
-//struct VDW radii2 = {3.0, 2.7, 2.8, 2.2, 2.7, 2.6, 2.2, 2.6, 2.2, 1.9};
 
 double getParam(struct VDW_params *param, char *atom_name)
 {
@@ -79,19 +75,18 @@ double calculateVDWEnergy(struct protein *prot, double gamma)
 								   prot->atoms[j].coordinates);
 				distance = vectorMagnitude(bond_vector);
 				free(bond_vector);
+				mixed_sigma =
+					mixedSigma(prot->atoms[i].atom_name,
+							   prot->atoms[j].atom_name);
+				fprintf(stderr, "%f %f\n", distance, mixed_sigma);
 				if (distance <
-					gamma * getVDWRadii(&radii,
-										prot->atoms[i].atom_name,
-										prot->atoms[j].atom_name)
+					gamma * mixed_sigma
 					&& ((isBackbone(prot->atoms[i].atom_type)
 						 && !isBackbone(prot->atoms[j].atom_type))
 						|| (!isBackbone(prot->atoms[i].atom_type)
 							&& isBackbone(prot->atoms[j].atom_type)))) {
 					return NAN;
 				}
-				mixed_sigma =
-					mixedSigma(prot->atoms[i].atom_name,
-							   prot->atoms[j].atom_name);
 				mixed_epsilon =
 					mixedEpsilon(prot->atoms[i].atom_name,
 								 prot->atoms[j].atom_name);

--- a/src/utils/vdwEnergy/vdwEnergy.c
+++ b/src/utils/vdwEnergy/vdwEnergy.c
@@ -78,7 +78,6 @@ double calculateVDWEnergy(struct protein *prot, double gamma)
 				mixed_sigma =
 					mixedSigma(prot->atoms[i].atom_name,
 							   prot->atoms[j].atom_name);
-				fprintf(stderr, "%f %f\n", distance, mixed_sigma);
 				if (distance <
 					gamma * mixed_sigma
 					&& ((isBackbone(prot->atoms[i].atom_type)


### PR DESCRIPTION
change cutoff from steric definitions from Ramachandran to the mixed sigma values of the VDW potential for `vdwScan`. The Ramachandran values are still used in `stericScan`. Many other changes in this PR are formatting which should have been in it's own PR but laziness took over.