### PR TITLE
Fix rotation bug for arginine side chains

### DIFF
--- a/src/utils/readProtein/readProtein.c
+++ b/src/utils/readProtein/readProtein.c
@@ -71,7 +71,7 @@ readPDB(struct protein *prot, char *filename, FILE * log,
 					prot->atoms[line_number].atom_number;
 				bb_atoms += 1;
 			} else {
-				prot->residues[res_num -
+			    prot->residues[res_num -
 							   1].sidechain_atoms[sc_atoms] =
 					prot->atoms[line_number].atom_number;
 				sc_atoms += 1;

--- a/src/utils/readProtein/readProtein.h
+++ b/src/utils/readProtein/readProtein.h
@@ -46,7 +46,7 @@ struct _residues {
 	int num_bb_atoms;
 	int num_sc_atoms;
 	int backbone_atoms[8];		//backbone atom numbers for a residue. 8 is the most backbone atoms possible (N- (NH3) or C-terminal (COOH) glycine with 8 atoms)
-	int sidechain_atoms[19];	//side chain atom numbers for a residue. 18 is the most side chain atoms possible (Arg or Trp)
+	int sidechain_atoms[19];	//side chain atom numbers for a residue. 19 is the most side chain atoms possible (Arg or Trp)
 };
 
 struct protein {

--- a/src/utils/readProtein/readProtein.h
+++ b/src/utils/readProtein/readProtein.h
@@ -46,7 +46,7 @@ struct _residues {
 	int num_bb_atoms;
 	int num_sc_atoms;
 	int backbone_atoms[8];		//backbone atom numbers for a residue. 8 is the most backbone atoms possible (N- (NH3) or C-terminal (COOH) glycine with 8 atoms)
-	int sidechain_atoms[18];	//side chain atom numbers for a residue. 18 is the most side chain atoms possible (Arg or Trp)
+	int sidechain_atoms[19];	//side chain atom numbers for a residue. 18 is the most side chain atoms possible (Arg or Trp)
 };
 
 struct protein {
@@ -62,10 +62,10 @@ struct protein {
 };
 
 //list of backbone atoms including NH3 and COOH termini atoms
-static char *backbone_atom_list[15] =
-	{ "N", "H1", "H2", "H3", "HN", "HA", "HA1", "HA2", "CA", "C", "O",
-	"OT",
-	"OT1", "OT2", "HT2"
+static char *backbone_atom_list[18] =
+	{ "N", "H", "H1", "H2", "H3", "HN", "HA", "HA1", "HA2", "CA", "C", "O",
+	"OT", "OT1", "OT2", "HT2", // c-terminus
+	"OC1", "OC2" // more c-terminus options
 };
 
 static int size_bb_atom_list =


### PR DESCRIPTION
- Resolves #13 
- elongated side chain atoms list to a max of 19. At 18, it was not enough to store the final hydrogen of the arginine side chain and accessing that memory without allocation lead to rotating another atom in the structure (happened to be a CA or atom 5 in the structure) 
- added some extra atom definitions to backbone atoms list. Non terminal hydrogen of the amide groups (N-H) did not have a definition. Similarly, COO- C-terminus was not defined (OC1/2).